### PR TITLE
Use GNUInstallDirs for install locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ pkg_check_modules(YAML REQUIRED IMPORTED_TARGET yaml-cpp)
 pkg_check_modules(LIBEVDEV REQUIRED IMPORTED_TARGET libevdev)
 find_package(nlohmann_json 3.2.0 REQUIRED)
 
+include(GNUInstallDirs)
+
 add_executable(miracle-wm
     src/main.cpp
     src/miracle_window_management_policy.cpp
@@ -41,10 +43,11 @@ target_include_directories(miracle-wm PUBLIC SYSTEM ${MIRAL_INCLUDE_DIRS})
 target_link_libraries(     miracle-wm               ${MIRAL_LDFLAGS} PkgConfig::YAML PkgConfig::GLIB PkgConfig::LIBEVDEV nlohmann_json::nlohmann_json)
 
 install(PROGRAMS ${CMAKE_BINARY_DIR}/bin/miracle-wm
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
-install(FILES session/usr/local/share/wayland-sessions/miracle-wm-non-snap.desktop
-    DESTINATION /usr/share/wayland-sessions)
+configure_file(session/usr/local/share/wayland-sessions/miracle-wm-non-snap.desktop.in miracle-wm-non-snap.desktop @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/miracle-wm-non-snap.desktop
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/wayland-sessions)
 
 add_subdirectory(tests/)

--- a/session/usr/local/share/wayland-sessions/miracle-wm-non-snap.desktop.in
+++ b/session/usr/local/share/wayland-sessions/miracle-wm-non-snap.desktop.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
 Name=Miracle Non Snap
 Comment=A wayland tiling window manager based on Mir
-Exec=sh -l -c /usr/local/bin/miracle-wm
+Exec=sh -l -c @CMAKE_INSTALL_FULL_BINDIR@/miracle-wm
 Type=Application


### PR DESCRIPTION
To support prefixes that aren't `/usr` / `/usr/local`.