### PR TITLE
refactor: window management and node discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ include(GNUInstallDirs)
 
 add_executable(miracle-wm
     src/main.cpp
-    src/miracle_window_management_policy.cpp
+    src/tiling_window_management_policy.cpp
     src/window_tree.cpp
     src/node.cpp
     src/window_helpers.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(miracle-wm
     src/ipc.cpp
     src/auto_restarting_launcher.cpp
     src/workspace_observer.cpp
+    src/window_metadata.cpp
 )
 
 target_include_directories(miracle-wm PUBLIC SYSTEM ${MIRAL_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ include(GNUInstallDirs)
 add_executable(miracle-wm
     src/main.cpp
     src/tiling_window_management_policy.cpp
-    src/window_tree.cpp
+    src/tree.cpp
     src/node.cpp
     src/window_helpers.h
     src/window_helpers.cpp

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 #define MIR_LOG_COMPONENT "miracle-main"
 
-#include "miracle_window_management_policy.h"
+#include "tiling_window_management_policy.h"
 #include "miracle_config.h"
 #include "auto_restarting_launcher.h"
 
@@ -29,7 +29,7 @@ int main(int argc, char const* argv[])
     auto config = std::make_shared<miracle::MiracleConfig>(runner);
     WindowManagerOptions window_managers
     {
-        add_window_manager_policy<miracle::MiracleWindowManagementPolicy>(
+        add_window_manager_policy<miracle::TilingWindowManagementPolicy>(
             "tiling", external_client_launcher, internal_client_launcher, runner, config)
     };
 

--- a/src/node.h
+++ b/src/node.h
@@ -14,6 +14,7 @@ namespace geom = mir::geometry;
 namespace miracle
 {
 class MiracleConfig;
+class Tree;
 
 enum class NodeState
 {
@@ -31,12 +32,17 @@ enum class NodeLayoutDirection
 class Node : public std::enable_shared_from_this<Node>
 {
 public:
-    Node(miral::WindowManagerTools const& tools, geom::Rectangle const&, std::shared_ptr<MiracleConfig> const& config);
     Node(miral::WindowManagerTools const& tools,
-         geom::Rectangle const&,
+         geom::Rectangle const& area,
+         std::shared_ptr<MiracleConfig> const& config,
+         Tree const* tree);
+
+    Node(miral::WindowManagerTools const& tools,
+         geom::Rectangle const& area,
          std::shared_ptr<Node> parent,
          std::shared_ptr<WindowMetadata> const& metadata,
-         std::shared_ptr<MiracleConfig> const& config);
+         std::shared_ptr<MiracleConfig> const& config,
+         Tree const* tree);
 
     /// Area taken up by the node including gaps.
     geom::Rectangle get_logical_area();
@@ -58,10 +64,6 @@ public:
 
     // Translates the logical area by the provided amount
     void translate_by(int x, int y);
-
-    /// Walk the tree to find the lane that contains this window.
-    /// @returns The node if it is found, otherwise false
-    std::shared_ptr<Node> find_node_for_window(miral::Window& window);
 
     /// Insert a node at a particular index
     void insert_node(std::shared_ptr<Node> const& node, int index);
@@ -98,10 +100,12 @@ public:
     miral::Window& get_window() { return metadata->get_window(); }
     std::shared_ptr<Node> get_parent() const { return parent; }
     std::vector<std::shared_ptr<Node>> const& get_sub_nodes() const { return sub_nodes; }
+    Tree const* get_tree() { return tree; }
 
 private:
     std::shared_ptr<Node> parent;
     miral::WindowManagerTools tools;
+    Tree const* tree;
     std::shared_ptr<WindowMetadata> metadata;
     std::vector<std::shared_ptr<Node>> sub_nodes;
     std::vector<std::shared_ptr<Node>> hidden_nodes;

--- a/src/node.h
+++ b/src/node.h
@@ -1,6 +1,7 @@
 #ifndef NODE_H
 #define NODE_H
 
+#include "window_metadata.h"
 #include <mir/geometry/rectangle.h>
 #include <vector>
 #include <memory>
@@ -31,7 +32,11 @@ class Node : public std::enable_shared_from_this<Node>
 {
 public:
     Node(miral::WindowManagerTools const& tools, geom::Rectangle const&, std::shared_ptr<MiracleConfig> const& config);
-    Node(miral::WindowManagerTools const& tools, geom::Rectangle const&, std::shared_ptr<Node> parent, miral::Window& window, std::shared_ptr<MiracleConfig> const& config);
+    Node(miral::WindowManagerTools const& tools,
+         geom::Rectangle const&,
+         std::shared_ptr<Node> parent,
+         std::shared_ptr<WindowMetadata> const& metadata,
+         std::shared_ptr<MiracleConfig> const& config);
 
     /// Area taken up by the node including gaps.
     geom::Rectangle get_logical_area();
@@ -90,14 +95,14 @@ public:
     bool is_window() const { return state == NodeState::window; }
     bool is_lane() const { return state == NodeState::lane; }
     NodeLayoutDirection get_direction() const { return direction; }
-    miral::Window& get_window() { return window; }
+    miral::Window& get_window() { return metadata->get_window(); }
     std::shared_ptr<Node> get_parent() const { return parent; }
     std::vector<std::shared_ptr<Node>> const& get_sub_nodes() const { return sub_nodes; }
 
 private:
     std::shared_ptr<Node> parent;
     miral::WindowManagerTools tools;
-    miral::Window window;
+    std::shared_ptr<WindowMetadata> metadata;
     std::vector<std::shared_ptr<Node>> sub_nodes;
     std::vector<std::shared_ptr<Node>> hidden_nodes;
     NodeState state;

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -18,12 +18,12 @@ Screen::Screen(
 {
 }
 
-WindowTree &Screen::get_active_tree()
+Tree &Screen::get_active_tree()
 {
     for (auto& info : workspaces)
     {
         if (info.workspace == active_workspace)
-            return info.tree;
+            return *info.tree;
     }
 
     throw std::runtime_error("Unable to find the active tree. We shouldn't be here");
@@ -31,10 +31,7 @@ WindowTree &Screen::get_active_tree()
 
 void Screen::advise_new_workspace(int workspace)
 {
-    workspaces.push_back({
-        workspace,
-        WindowTree(this, tools, config)
-    });
+    workspaces.push_back({workspace, std::make_shared<Tree>(this, tools, config)});
 }
 
 void Screen::advise_workspace_deleted(int workspace)
@@ -74,7 +71,7 @@ bool Screen::advise_workspace_active(int key)
             if (previous_workspace != nullptr)
             {
                 auto& active_tree = previous_workspace->tree;
-                if (active_tree.is_empty())
+                if (active_tree->is_empty())
                     workspace_manager.delete_workspace(previous_workspace->workspace);
             }
             return true;
@@ -86,12 +83,12 @@ bool Screen::advise_workspace_active(int key)
 
 void Screen::hide(ScreenWorkspaceInfo& info)
 {
-    info.tree.hide();
+    info.tree->hide();
 }
 
 void Screen::show(ScreenWorkspaceInfo& info)
 {
-     info.tree.show();
+     info.tree->show();
 }
 
 const ScreenWorkspaceInfo &Screen::get_workspace(int key)
@@ -111,7 +108,7 @@ void Screen::advise_application_zone_create(miral::Zone const& application_zone)
     {
         application_zone_list.push_back(application_zone);
         for (auto& workspace : workspaces)
-            workspace.tree._recalculate_root_node_area();
+            workspace.tree->recalculate_root_node_area();
     }
 }
 
@@ -122,7 +119,7 @@ void Screen::advise_application_zone_update(miral::Zone const& updated, miral::Z
         {
             zone = updated;
             for (auto& workspace : workspaces)
-                workspace.tree._recalculate_root_node_area();
+                workspace.tree->recalculate_root_node_area();
             break;
         }
 }
@@ -132,7 +129,7 @@ void Screen::advise_application_zone_delete(miral::Zone const& application_zone)
     if (std::remove(application_zone_list.begin(), application_zone_list.end(), application_zone) != application_zone_list.end())
     {
         for (auto& workspace : workspaces)
-            workspace.tree._recalculate_root_node_area();
+            workspace.tree->recalculate_root_node_area();
     }
 }
 

--- a/src/screen.h
+++ b/src/screen.h
@@ -1,7 +1,7 @@
 #ifndef MIRACLE_SCREEN_H
 #define MIRACLE_SCREEN_H
 
-#include "window_tree.h"
+#include "tree.h"
 #include <memory>
 #include <miral/output.h>
 
@@ -20,7 +20,7 @@ struct NodeResurrection
 struct ScreenWorkspaceInfo
 {
     int workspace;
-    WindowTree tree;
+    std::shared_ptr<Tree> tree;
     std::vector<NodeResurrection> nodes_to_resurrect;
 };
 
@@ -38,7 +38,7 @@ public:
         std::shared_ptr<MiracleConfig> const& options);
     ~Screen() = default;
 
-    WindowTree& get_active_tree();
+    Tree& get_active_tree();
     int get_active_workspace() const { return active_workspace; }
     void advise_new_workspace(int workspace);
     void advise_workspace_deleted(int workspace);

--- a/src/tiling_window_management_policy.cpp
+++ b/src/tiling_window_management_policy.cpp
@@ -380,7 +380,7 @@ void TilingWindowManagementPolicy::advise_output_update(miral::Output const& upd
         {
             for (auto& workspace : output->get_workspaces())
             {
-                workspace.tree.set_output_area(updated.extents());
+                workspace.tree->set_output_area(updated.extents());
             }
             break;
         }
@@ -402,7 +402,7 @@ void TilingWindowManagementPolicy::advise_output_delete(miral::Output const& out
                     // All nodes should become orphaned
                     for (auto& workspace : other_output->get_workspaces())
                     {
-                        workspace.tree.foreach_node([&](auto node)
+                        workspace.tree->foreach_node([&](auto node)
                         {
                             if (node->is_window())
                             {
@@ -451,7 +451,7 @@ void TilingWindowManagementPolicy::handle_modify_window(
                 bool found = false;
                 for (auto& workspace : output->get_workspaces())
                 {
-                    if (workspace.tree.advise_fullscreen_window(window_info))
+                    if (workspace.tree->advise_fullscreen_window(window_info))
                     {
                         found = true;
                         break;
@@ -468,7 +468,7 @@ void TilingWindowManagementPolicy::handle_modify_window(
                 bool found = false;
                 for (auto& workspace : output->get_workspaces())
                 {
-                    if (workspace.tree.advise_restored_window(window_info))
+                    if (workspace.tree->advise_restored_window(window_info))
                     {
                         found = true;
                         break;
@@ -485,7 +485,7 @@ void TilingWindowManagementPolicy::handle_modify_window(
         bool found = false;
         for (auto& workspace : output->get_workspaces())
         {
-            if (workspace.tree.constrain(window_info))
+            if (workspace.tree->constrain(window_info))
             {
                 found = true;
                 window_manager_tools.modify_window(window_info.window(), modifications);
@@ -509,19 +509,10 @@ TilingWindowManagementPolicy::confirm_placement_on_display(
     const mir::geometry::Rectangle &new_placement)
 {
     mir::geometry::Rectangle modified_placement = new_placement;
-    for (auto const& output : output_list)\
+    for (auto const& output : output_list)
     {
-        bool found = false;
-        for (auto& workspace : output->get_workspaces())
-        {
-            if (workspace.tree.confirm_placement_on_display(window_info, new_state, modified_placement))
-            {
-                found = true;
-                break;
-            }
-        }
-
-        if (found) break;
+        if (output->get_active_tree().confirm_placement_on_display(window_info, new_state, modified_placement))
+            break;
     }
     return modified_placement;
 }

--- a/src/tiling_window_management_policy.cpp
+++ b/src/tiling_window_management_policy.cpp
@@ -1,6 +1,6 @@
 #define MIR_LOG_COMPONENT "miracle"
 
-#include "miracle_window_management_policy.h"
+#include "tiling_window_management_policy.h"
 #include "window_helpers.h"
 #include "miracle_config.h"
 #include "workspace_manager.h"
@@ -60,7 +60,7 @@ const std::string POSSIBLE_TERMINALS[] = {
 };
 }
 
-MiracleWindowManagementPolicy::MiracleWindowManagementPolicy(
+TilingWindowManagementPolicy::TilingWindowManagementPolicy(
     miral::WindowManagerTools const& tools,
     miral::ExternalClientLauncher const& external_client_launcher,
     miral::InternalClientLauncher const& internal_client_launcher,
@@ -84,12 +84,12 @@ MiracleWindowManagementPolicy::MiracleWindowManagementPolicy(
     }, 1);
 }
 
-MiracleWindowManagementPolicy::~MiracleWindowManagementPolicy()
+TilingWindowManagementPolicy::~TilingWindowManagementPolicy()
 {
     workspace_observer_registrar.unregister_interest(*ipc);
 }
 
-bool MiracleWindowManagementPolicy::handle_keyboard_event(MirKeyboardEvent const* event)
+bool TilingWindowManagementPolicy::handle_keyboard_event(MirKeyboardEvent const* event)
 {
     auto const action = miral::toolkit::mir_keyboard_event_action(event);
     auto const scan_code = miral::toolkit::mir_keyboard_event_scan_code(event);
@@ -236,7 +236,7 @@ bool MiracleWindowManagementPolicy::handle_keyboard_event(MirKeyboardEvent const
     return false;
 }
 
-bool MiracleWindowManagementPolicy::handle_pointer_event(MirPointerEvent const* event)
+bool TilingWindowManagementPolicy::handle_pointer_event(MirPointerEvent const* event)
 {
     auto x = miral::toolkit::mir_pointer_event_axis_value(event, MirPointerAxis::mir_pointer_axis_x);
     auto y = miral::toolkit::mir_pointer_event_axis_value(event, MirPointerAxis::mir_pointer_axis_y);
@@ -264,7 +264,7 @@ bool MiracleWindowManagementPolicy::handle_pointer_event(MirPointerEvent const* 
     return false;
 }
 
-auto MiracleWindowManagementPolicy::place_new_window(
+auto TilingWindowManagementPolicy::place_new_window(
     const miral::ApplicationInfo &app_info,
     const miral::WindowSpecification &requested_specification) -> miral::WindowSpecification
 {
@@ -278,7 +278,7 @@ auto MiracleWindowManagementPolicy::place_new_window(
     return active_output->get_active_tree().allocate_position(requested_specification);
 }
 
-void MiracleWindowManagementPolicy::_add_to_output_immediately(miral::Window& window, std::shared_ptr<Screen>& output)
+void TilingWindowManagementPolicy::_add_to_output_immediately(miral::Window& window, std::shared_ptr<Screen>& output)
 {
     miral::WindowSpecification spec;
     spec = output->get_active_tree().allocate_position(spec);
@@ -286,7 +286,7 @@ void MiracleWindowManagementPolicy::_add_to_output_immediately(miral::Window& wi
     output->get_active_tree().advise_new_window(window_manager_tools.info_for(window));
 }
 
-void MiracleWindowManagementPolicy::advise_new_window(miral::WindowInfo const& window_info)
+void TilingWindowManagementPolicy::advise_new_window(miral::WindowInfo const& window_info)
 {
     auto shared_output = pending_output.lock();
     if (!shared_output)
@@ -312,7 +312,7 @@ void MiracleWindowManagementPolicy::advise_new_window(miral::WindowInfo const& w
     pending_output.reset();
 }
 
-void MiracleWindowManagementPolicy::handle_window_ready(miral::WindowInfo &window_info)
+void TilingWindowManagementPolicy::handle_window_ready(miral::WindowInfo &window_info)
 {
     for (auto const& output : output_list)
     {
@@ -321,20 +321,20 @@ void MiracleWindowManagementPolicy::handle_window_ready(miral::WindowInfo &windo
     }
 }
 
-void MiracleWindowManagementPolicy::advise_focus_gained(const miral::WindowInfo &window_info)
+void TilingWindowManagementPolicy::advise_focus_gained(const miral::WindowInfo &window_info)
 {
     for (auto const& output : output_list)
         output->get_active_tree().advise_focus_gained(window_info.window());
     window_manager_tools.raise_tree(window_info.window());
 }
 
-void MiracleWindowManagementPolicy::advise_focus_lost(const miral::WindowInfo &window_info)
+void TilingWindowManagementPolicy::advise_focus_lost(const miral::WindowInfo &window_info)
 {
     for (auto const& output : output_list)
         output->get_active_tree().advise_focus_lost(window_info.window());
 }
 
-void MiracleWindowManagementPolicy::advise_delete_window(const miral::WindowInfo &window_info)
+void TilingWindowManagementPolicy::advise_delete_window(const miral::WindowInfo &window_info)
 {
     for (auto it = orphaned_window_list.begin(); it != orphaned_window_list.end();)
     {
@@ -348,11 +348,11 @@ void MiracleWindowManagementPolicy::advise_delete_window(const miral::WindowInfo
         output->get_active_tree().advise_delete_window(window_info.window());
 }
 
-void MiracleWindowManagementPolicy::advise_move_to(miral::WindowInfo const& window_info, geom::Point top_left)
+void TilingWindowManagementPolicy::advise_move_to(miral::WindowInfo const& window_info, geom::Point top_left)
 {
 }
 
-void MiracleWindowManagementPolicy::advise_output_create(miral::Output const& output)
+void TilingWindowManagementPolicy::advise_output_create(miral::Output const& output)
 {
     auto new_tree = std::make_shared<Screen>(
         output, workspace_manager, output.extents(), window_manager_tools, config);
@@ -372,7 +372,7 @@ void MiracleWindowManagementPolicy::advise_output_create(miral::Output const& ou
     }
 }
 
-void MiracleWindowManagementPolicy::advise_output_update(miral::Output const& updated, miral::Output const& original)
+void TilingWindowManagementPolicy::advise_output_update(miral::Output const& updated, miral::Output const& original)
 {
     for (auto& output : output_list)
     {
@@ -387,7 +387,7 @@ void MiracleWindowManagementPolicy::advise_output_update(miral::Output const& up
     }
 }
 
-void MiracleWindowManagementPolicy::advise_output_delete(miral::Output const& output)
+void TilingWindowManagementPolicy::advise_output_delete(miral::Output const& output)
 {
     for (auto it = output_list.begin(); it != output_list.end();)
     {
@@ -427,7 +427,7 @@ void MiracleWindowManagementPolicy::advise_output_delete(miral::Output const& ou
     }
 }
 
-void MiracleWindowManagementPolicy::advise_state_change(miral::WindowInfo const& window_info, MirWindowState state)
+void TilingWindowManagementPolicy::advise_state_change(miral::WindowInfo const& window_info, MirWindowState state)
 {
     for (auto const& output : output_list)
     {
@@ -438,7 +438,7 @@ void MiracleWindowManagementPolicy::advise_state_change(miral::WindowInfo const&
     }
 }
 
-void MiracleWindowManagementPolicy::handle_modify_window(
+void TilingWindowManagementPolicy::handle_modify_window(
     miral::WindowInfo &window_info,
     const miral::WindowSpecification &modifications)
 {
@@ -497,13 +497,13 @@ void MiracleWindowManagementPolicy::handle_modify_window(
     }
 }
 
-void MiracleWindowManagementPolicy::handle_raise_window(miral::WindowInfo &window_info)
+void TilingWindowManagementPolicy::handle_raise_window(miral::WindowInfo &window_info)
 {
     window_manager_tools.select_active_window(window_info.window());
 }
 
 mir::geometry::Rectangle
-MiracleWindowManagementPolicy::confirm_placement_on_display(
+TilingWindowManagementPolicy::confirm_placement_on_display(
     const miral::WindowInfo &window_info,
     MirWindowState new_state,
     const mir::geometry::Rectangle &new_placement)
@@ -526,17 +526,17 @@ MiracleWindowManagementPolicy::confirm_placement_on_display(
     return modified_placement;
 }
 
-bool MiracleWindowManagementPolicy::handle_touch_event(const MirTouchEvent *event)
+bool TilingWindowManagementPolicy::handle_touch_event(const MirTouchEvent *event)
 {
     return false;
 }
 
-void MiracleWindowManagementPolicy::handle_request_move(miral::WindowInfo &window_info, const MirInputEvent *input_event)
+void TilingWindowManagementPolicy::handle_request_move(miral::WindowInfo &window_info, const MirInputEvent *input_event)
 {
 
 }
 
-void MiracleWindowManagementPolicy::handle_request_resize(
+void TilingWindowManagementPolicy::handle_request_resize(
     miral::WindowInfo &window_info,
     const MirInputEvent *input_event,
     MirResizeEdge edge)
@@ -544,14 +544,14 @@ void MiracleWindowManagementPolicy::handle_request_resize(
 
 }
 
-mir::geometry::Rectangle MiracleWindowManagementPolicy::confirm_inherited_move(
+mir::geometry::Rectangle TilingWindowManagementPolicy::confirm_inherited_move(
     const miral::WindowInfo &window_info,
     mir::geometry::Displacement movement)
 {
     return {window_info.window().top_left()+movement, window_info.window().size()};
 }
 
-void MiracleWindowManagementPolicy::advise_application_zone_create(miral::Zone const& application_zone)
+void TilingWindowManagementPolicy::advise_application_zone_create(miral::Zone const& application_zone)
 {
     for (auto const& output : output_list)
     {
@@ -559,7 +559,7 @@ void MiracleWindowManagementPolicy::advise_application_zone_create(miral::Zone c
     }
 }
 
-void MiracleWindowManagementPolicy::advise_application_zone_update(miral::Zone const& updated, miral::Zone const& original)
+void TilingWindowManagementPolicy::advise_application_zone_update(miral::Zone const& updated, miral::Zone const& original)
 {
     for (auto const& output : output_list)
     {
@@ -567,7 +567,7 @@ void MiracleWindowManagementPolicy::advise_application_zone_update(miral::Zone c
     }
 }
 
-void MiracleWindowManagementPolicy::advise_application_zone_delete(miral::Zone const& application_zone)
+void TilingWindowManagementPolicy::advise_application_zone_delete(miral::Zone const& application_zone)
 {
     for (auto const& output : output_list)
     {

--- a/src/tiling_window_management_policy.h
+++ b/src/tiling_window_management_policy.h
@@ -1,5 +1,5 @@
-#ifndef MIRIACLE_WINDOW_MANAGEMENT_POLICY_H
-#define MIRIACLE_WINDOW_MANAGEMENT_POLICY_H
+#ifndef MIRACLE_TILING_WINDOW_MANAGEMENT_POLICY_H
+#define MIRACLE_TILING_WINDOW_MANAGEMENT_POLICY_H
 
 #include "screen.h"
 #include "miracle_config.h"
@@ -22,16 +22,16 @@ class MirRunner;
 namespace miracle
 {
 
-class MiracleWindowManagementPolicy : public miral::WindowManagementPolicy
+class TilingWindowManagementPolicy : public miral::WindowManagementPolicy
 {
 public:
-    MiracleWindowManagementPolicy(
+    TilingWindowManagementPolicy(
         miral::WindowManagerTools const&,
         miral::ExternalClientLauncher const&,
         miral::InternalClientLauncher const&,
         miral::MirRunner&,
         std::shared_ptr<MiracleConfig> const&);
-    ~MiracleWindowManagementPolicy() override;
+    ~TilingWindowManagementPolicy() override;
 
     bool handle_keyboard_event(MirKeyboardEvent const* event) override;
     bool handle_pointer_event(MirPointerEvent const* event) override;
@@ -95,4 +95,4 @@ private:
 };
 }
 
-#endif //MIRIACLE_WINDOW_MANAGEMENT_POLICY_H
+#endif //MIRACLE_TILING_WINDOW_MANAGEMENT_POLICY_H

--- a/src/tree.h
+++ b/src/tree.h
@@ -27,12 +27,11 @@ enum class Direction
     right
 };
 
-/// Represents a tiling tree for an output.
-class WindowTree
+class Tree
 {
 public:
-    WindowTree(Screen* parent, miral::WindowManagerTools const& tools, std::shared_ptr<MiracleConfig> const& options);
-    ~WindowTree();
+    Tree(Screen* parent, miral::WindowManagerTools const& tools, std::shared_ptr<MiracleConfig> const& options);
+    ~Tree();
 
     /// Makes space for the new window and returns its specified spot in the grid. Note that the returned
     /// position is the position WITH GAPS.
@@ -88,7 +87,7 @@ public:
     /// Constrains the window to its tile if it is in this tree.
     bool constrain(miral::WindowInfo& window_info);
 
-    void add_tree(WindowTree&);
+    void add_tree(std::shared_ptr<Tree> const&);
 
     void foreach_node(std::function<void(std::shared_ptr<Node>)> const&);
     void close_active_window();
@@ -100,7 +99,7 @@ public:
     void show();
 
     std::shared_ptr<Node> get_root_node();
-    void _recalculate_root_node_area();
+    void recalculate_root_node_area();
     bool is_empty();
 
 private:
@@ -132,8 +131,6 @@ private:
     std::vector<NodeResurrection> nodes_to_resurrect;
     int config_handle = 0;
 
-    // TODO: Move non tiling window list to Screen
-    std::vector<miral::Window> non_tiling_window_list;
     std::shared_ptr<Node> _get_active_lane();
     void _handle_direction_request(NodeLayoutDirection direction);
     void _handle_resize_request(std::shared_ptr<Node> const& node, Direction direction, int amount);

--- a/src/window_helpers.cpp
+++ b/src/window_helpers.cpp
@@ -1,4 +1,9 @@
+#define MIR_LOG_COMPONENT "window_helpers"
+
 #include "window_helpers.h"
+#include "window_metadata.h"
+#include "node.h"
+#include <mir/log.h>
 
 bool miracle::window_helpers::is_window_fullscreen(MirWindowState state)
 {
@@ -6,4 +11,33 @@ bool miracle::window_helpers::is_window_fullscreen(MirWindowState state)
            || state == mir_window_state_maximized
            || state == mir_window_state_horizmaximized
            || state == mir_window_state_vertmaximized;
+}
+
+std::shared_ptr<miracle::Node> miracle::window_helpers::get_node_for_window(
+    miral::Window const& window,
+    miral::WindowManagerTools const& tools)
+{
+    auto& info = tools.info_for(window);
+    if (info.userdata())
+    {
+        std::shared_ptr<WindowMetadata> data = static_pointer_cast<WindowMetadata>(info.userdata());
+        return data->get_tiling_node();
+    }
+
+    mir::log_error("Unable to find node for window");
+    return nullptr;
+}
+
+std::shared_ptr<miracle::Node> miracle::window_helpers::get_node_for_window_by_tree(
+    const miral::Window &window,
+    const miral::WindowManagerTools &tools,
+    const miracle::Tree *tree)
+{
+    auto node = get_node_for_window(window, tools);
+    if (node && node->get_tree() == tree)
+    {
+        return node;
+    }
+
+    return nullptr;
 }

--- a/src/window_helpers.h
+++ b/src/window_helpers.h
@@ -2,9 +2,13 @@
 #define MIRACLEWM_WINDOW_HELPERS_H
 
 #include <miral/window_info.h>
+#include <miral/window_manager_tools.h>
 
 namespace miracle
 {
+class Node;
+class Tree;
+
 namespace window_helpers
 {
 bool is_window_fullscreen(MirWindowState state);
@@ -19,6 +23,15 @@ bool is_tileable(T const& requested_specification)
            && (state == mir_window_state_restored || state == mir_window_state_maximized)
            && !has_exclusive_rect;
 }
+
+std::shared_ptr<Node> get_node_for_window(
+    miral::Window const& window,
+    miral::WindowManagerTools const& tools);
+
+std::shared_ptr<Node> get_node_for_window_by_tree(
+    miral::Window const& window,
+    miral::WindowManagerTools const& tools,
+    Tree const* tree);
 }
 }
 

--- a/src/window_metadata.cpp
+++ b/src/window_metadata.cpp
@@ -1,0 +1,13 @@
+#include "window_metadata.h"
+
+using namespace miracle;
+
+WindowMetadata::WindowMetadata(miracle::WindowType type, miral::Window const& window)
+    : type{type},
+      window{window}
+{}
+
+void WindowMetadata::associate_to_node(std::shared_ptr<Node> const& node)
+{
+    tiling_node = node;
+}

--- a/src/window_metadata.h
+++ b/src/window_metadata.h
@@ -1,0 +1,41 @@
+#ifndef MIRACLEWM_WINDOW_METADATA_H
+#define MIRACLEWM_WINDOW_METADATA_H
+
+#include <memory>
+#include <miral/window.h>
+#include <miral/window_manager_tools.h>
+
+namespace miracle
+{
+
+class Node;
+
+enum class WindowType
+{
+    tiled,
+    floating
+};
+
+/// Applied to WindowInfo to enable
+class WindowMetadata
+{
+public:
+    WindowMetadata(WindowType type, miral::Window const& window);
+    void associate_to_node(std::shared_ptr<Node> const&);
+    miral::Window& get_window() { return window; }
+    std::shared_ptr<Node> get_tiling_node() {
+        if (type == WindowType::tiled)
+            return tiling_node;
+        return nullptr;
+    }
+
+private:
+
+    WindowType type;
+    miral::Window window;
+    std::shared_ptr<Node> tiling_node;
+};
+
+}
+
+#endif //MIRACLEWM_WINDOW_METADATA_H

--- a/src/workspace_manager.cpp
+++ b/src/workspace_manager.cpp
@@ -1,6 +1,7 @@
 #define MIR_LOG_COMPONENT "workspace_manager"
 #include "workspace_manager.h"
 #include "screen.h"
+#include "window_helpers.h"
 #include <mir/log.h>
 
 using namespace mir::geometry;
@@ -68,7 +69,7 @@ bool WorkspaceManager::move_active_to_workspace(std::shared_ptr<Screen> screen, 
         return false;
 
     auto& original_tree = screen->get_active_tree();
-    auto window_node = original_tree.get_root_node()->find_node_for_window(window);
+    auto window_node = window_helpers::get_node_for_window(window, tools_);
     original_tree.advise_delete_window(window);
 
     auto screen_to_move_to = request_workspace(screen, workspace);


### PR DESCRIPTION
## What's new?
- Refactored window management and node discovery in preparation for a floating window manager
- This includes making node discovery a pointer jump instead of a tree search (huge for performance!)
- Renamed WindowTree to Tree
- Renamed MiracleWindowManagementPolicy to TilingWindowManagementPolicy