### PR TITLE
bugfix: fullscreen windows no longer crash the application

### DIFF
--- a/src/leaf_node.h
+++ b/src/leaf_node.h
@@ -41,6 +41,7 @@ public:
     void show();
     void hide();
     void toggle_fullscreen();
+    bool is_fullscreen() const;
     void constrain() override;
     size_t get_min_width() const override;
     size_t get_min_height() const override;
@@ -51,6 +52,7 @@ public:
 private:
     TilingInterface& node_interface;
     geom::Rectangle logical_area;
+    std::optional<geom::Rectangle> next_logical_area;
     std::shared_ptr<MiracleConfig> config;
     TilingWindowTree* tree;
     miral::Window window;

--- a/src/output_content.cpp
+++ b/src/output_content.cpp
@@ -241,13 +241,7 @@ void OutputContent::advise_state_change(const std::shared_ptr<miracle::WindowMet
     switch (metadata->get_type())
     {
         case WindowType::tiled:
-        {
-            if (get_active_tree().get() != metadata->get_tiling_node()->get_tree())
-                break;
-
-            metadata->get_tiling_node()->get_tree()->advise_state_change(metadata->get_window(), state);
             break;
-        }
         case WindowType::floating:
             if (!get_active_workspace()->has_floating_window(metadata->get_window()))
                 break;

--- a/src/policy.cpp
+++ b/src/policy.cpp
@@ -430,18 +430,6 @@ void Policy::advise_output_delete(miral::Output const& output)
     }
 }
 
-void Policy::advise_state_change(miral::WindowInfo const& window_info, MirWindowState state)
-{
-    auto metadata = window_helpers::get_metadata(window_info);
-    if (!metadata)
-    {
-        mir::log_error("advise_state_changed: metadata is not provided");
-        return;
-    }
-
-    if (metadata->get_output()) metadata->get_output()->advise_state_change(metadata, state);
-}
-
 void Policy::handle_modify_window(
     miral::WindowInfo &window_info,
     const miral::WindowSpecification &modifications)

--- a/src/policy.h
+++ b/src/policy.h
@@ -49,7 +49,6 @@ public:
     void advise_output_create(miral::Output const& output) override;
     void advise_output_update(miral::Output const& updated, miral::Output const& original) override;
     void advise_output_delete(miral::Output const& output) override;
-    void advise_state_change(miral::WindowInfo const& window_info, MirWindowState state) override;
     void handle_modify_window(miral::WindowInfo &window_info, const miral::WindowSpecification &modifications) override;
 
     void handle_raise_window(miral::WindowInfo &window_info) override;

--- a/src/tiling_window_tree.cpp
+++ b/src/tiling_window_tree.cpp
@@ -658,7 +658,7 @@ bool TilingWindowTree::advise_restored_window(miral::Window& window)
     {
         is_active_window_fullscreen = false;
         active_window->set_logical_area(active_window->get_logical_area());
-        constrain(active_window->get_window());
+        active_window->commit_changes();
     }
 
     return true;
@@ -689,21 +689,6 @@ bool TilingWindowTree::advise_state_change(miral::Window const& window, MirWindo
     if (is_hidden)
         return true;
 
-    auto node = metadata->get_tiling_node();
-    switch (state)
-    {
-        case mir_window_state_restored:
-            node->show();
-            break;
-        case mir_window_state_hidden:
-        case mir_window_state_minimized:
-            node->hide();
-            break;
-        default:
-            break;
-    }
-
-    node->commit_changes();
     return true;
 }
 
@@ -804,9 +789,14 @@ void TilingWindowTree::show()
         {
             leaf_node->show();
             leaf_node->commit_changes();
+
+            if (leaf_node->is_fullscreen())
+            {
+                tiling_interface.select_active_window(leaf_node->get_window());
+                tiling_interface.raise(leaf_node->get_window());
+            }
         }
     });
-
 }
 
 bool TilingWindowTree::is_empty()

--- a/src/window_manager_tools_tiling_interface.cpp
+++ b/src/window_manager_tools_tiling_interface.cpp
@@ -45,8 +45,8 @@ void WindowManagerToolsTilingInterface::change_state(miral::Window const& window
     auto& window_info = tools.info_for(window);
     miral::WindowSpecification spec;
     spec.state() = state;
-    tools.modify_window(window, spec);
     tools.place_and_size_for_state(spec, window_info);
+    tools.modify_window(window, spec);
 }
 
 void WindowManagerToolsTilingInterface::clip(miral::Window const& window, geom::Rectangle const& r)


### PR DESCRIPTION
## What's new?
- Fixed an error when fullscreening a window would crash it
- Fullscreen windows are now always put up-front-and-center when a workspace is re-shown