### PR TITLE
(#82) Fix bug where outputs fail to resize the tiling window tree

### DIFF
--- a/src/leaf_node.cpp
+++ b/src/leaf_node.cpp
@@ -56,18 +56,6 @@ void LeafNode::set_parent(std::shared_ptr<ParentNode> const& in_parent)
     parent = in_parent;
 }
 
-void LeafNode::scale_area(double x, double y)
-{
-    logical_area.size.width = geom::Width{ceil(x * logical_area.size.width.as_int())};
-    logical_area.size.height = geom::Height {ceil(y * logical_area.size.height.as_int())};
-}
-
-void LeafNode::translate(int x, int y)
-{
-    logical_area.top_left.x = geom::X{logical_area.top_left.x.as_int() + x};
-    logical_area.top_left.y = geom::Y{logical_area.top_left.y.as_int() + y};
-}
-
 geom::Rectangle LeafNode::get_visible_area() const
 {
     // TODO: Could cache these half values in the config

--- a/src/leaf_node.h
+++ b/src/leaf_node.h
@@ -53,8 +53,6 @@ public:
     [[nodiscard]] geom::Rectangle get_visible_area() const;
     void set_logical_area(geom::Rectangle const& target_rect) override;
     void set_parent(std::shared_ptr<ParentNode> const&) override;
-    void scale_area(double x, double y) override;
-    void translate(int x, int y) override;
     void show();
     void hide();
     void toggle_fullscreen();

--- a/src/node.h
+++ b/src/node.h
@@ -51,8 +51,6 @@ public:
     virtual void set_logical_area(geom::Rectangle const&) = 0;
     virtual void constrain() = 0;
     virtual void set_parent(std::shared_ptr<ParentNode> const&) = 0;
-    virtual void scale_area(double x, double y) = 0;
-    virtual void translate(int x, int y) = 0;
     virtual size_t get_min_height() const = 0;
     virtual size_t get_min_width() const = 0;
     bool is_leaf();

--- a/src/parent_node.cpp
+++ b/src/parent_node.cpp
@@ -347,29 +347,6 @@ void ParentNode::set_logical_area(const geom::Rectangle &target_rect)
     }
 }
 
-void ParentNode::scale_area(double x, double y)
-{
-    logical_area.size.width = geom::Width{ceil(x * logical_area.size.width.as_int())};
-    logical_area.size.height = geom::Height {ceil(y * logical_area.size.height.as_int())};
-
-    for (auto const& node : sub_nodes)
-        node->scale_area(x, y);
-
-    relayout();
-    constrain();
-}
-
-void ParentNode::translate(int x, int y)
-{
-    logical_area.top_left.x = geom::X{logical_area.top_left.x.as_int() + x};
-    logical_area.top_left.y = geom::Y{logical_area.top_left.y.as_int() + y};
-    for (auto const& node : sub_nodes)
-        node->translate(x, y);
-
-    relayout();
-    constrain();
-}
-
 void ParentNode::commit_changes()
 {
     for (auto& node : sub_nodes)

--- a/src/parent_node.h
+++ b/src/parent_node.h
@@ -47,8 +47,6 @@ public:
     void graft_existing(std::shared_ptr<Node> const& node, int index);
     void convert_to_lane(std::shared_ptr<LeafNode> const&);
     void set_logical_area(geom::Rectangle const& target_rect) override;
-    void scale_area(double x_scale, double y_scale) override;
-    void translate(int x, int y) override;
     void set_direction(NodeLayoutDirection direction);
     void swap_nodes(std::shared_ptr<Node> const& first, std::shared_ptr<Node> const& second);
     void remove(std::shared_ptr<Node> const& node);

--- a/src/tiling_window_tree.cpp
+++ b/src/tiling_window_tree.cpp
@@ -180,19 +180,8 @@ bool TilingWindowTree::try_toggle_active_fullscreen()
 
 void TilingWindowTree::set_output_area(geom::Rectangle const& new_area)
 {
-    auto area = screen->get_area();
-    double x_scale = static_cast<double>(new_area.size.width.as_int()) / static_cast<double>(area.size.width.as_int());
-    double y_scale = static_cast<double>(new_area.size.height.as_int()) / static_cast<double>(area.size.height.as_int());
-
-    int position_diff_x = new_area.top_left.x.as_int() - area.top_left.x.as_int();
-    int position_diff_y = new_area.top_left.y.as_int() - area.top_left.y.as_int();
-    area.top_left = new_area.top_left;
-    area.size = geom::Size{
-        geom::Width{ceil(area.size.width.as_int() * x_scale)},
-        geom::Height {ceil(area.size.height.as_int() * y_scale)}};
-
-    root_lane->scale_area(x_scale, y_scale);
-    root_lane->translate(position_diff_x, position_diff_y);
+    root_lane->set_logical_area(new_area);
+    root_lane->commit_changes();
 }
 
 std::shared_ptr<LeafNode> TilingWindowTree::select_window_from_point(int x, int y)


### PR DESCRIPTION
## What's new?
- Removed the `scale_area` and `translate` methods as they were unnecessary
- Using `set_logical_area` and `commit_changes` to make changes on output resize