### PR TITLE
Add dependencies to the README and mir-graphics-drivers-nvidia to the snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ sudo snap install miracle-wm --classic --edge
 > too lazy to implement them at this moment. I will happily accept contributions in this domain.
 
 
+# Dependencies
+- [cmake](https://cmake.org/) >= 3.7
+- [gcc](https://gcc.gnu.org/) or [clang](https://clang.llvm.org/) with C++20 support
+- [miral](https://canonical-mir.readthedocs-hosted.com/stable/getting_and_using_mir/) >= 6
+- [mir-graphics-drivers-desktop](https://canonical-mir.readthedocs-hosted.com/stable/getting_and_using_mir/) >= 2.14
+- [mir-graphics-drivers-nvidia](https://canonical-mir.readthedocs-hosted.com/stable/getting_and_using_mir/) >= 2.14 (NVIDIA Only)
+- [glib-2.0](https://docs.gtk.org/glib/)
+- [yaml-cpp](https://github.com/jbeder/yaml-cpp)
+- [libevdev](https://www.freedesktop.org/wiki/Software/libevdev/)
+- [nlohmann json](https://github.com/nlohmann/json) >= 3.2.0
+- [libnotify](https://gitlab.gnome.org/GNOME/libnotify)
+- [libxkbcommon-devel](https://github.com/xkbcommon/libxkbcommon)
+
 # Building
 **From Source**:
 ```sh

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -68,6 +68,7 @@ parts:
     stage-packages:
       - libmiral6
       - mir-graphics-drivers-desktop
+      - mir-graphics-drivers-nvidia
     prime:
       - -lib/udev
       - -usr/doc


### PR DESCRIPTION
# What's new?
- Adding a list of the dependencies to the README
- Add `mir-graphics-drivers-nvidia` to the stage-packages of the snap