### PR TITLE
(#95) No longer reloading startup applications when the config gets refreshed, threadsafe config updates, and commiting changes when we recalculate the root area node

### DIFF
--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -336,12 +336,6 @@ Ipc::IpcClient &Ipc::get_client(int fd)
     throw std::runtime_error("Could not find IPC client");
 }
 
-void Ipc::disconnect_all()
-{
-    for (auto& client : clients)
-        disconnect(client);
-}
-
 void Ipc::disconnect(Ipc::IpcClient& client)
 {
     auto it = std::find_if(clients.begin(), clients.end(), [&](IpcClient const& other)

--- a/src/ipc.h
+++ b/src/ipc.h
@@ -79,7 +79,6 @@ public:
     void on_created(std::shared_ptr<OutputContent> const& info, int key) override;
     void on_removed(std::shared_ptr<OutputContent> const& info, int key) override;
     void on_focused(std::shared_ptr<OutputContent> const& previous, int, std::shared_ptr<OutputContent> const& current, int) override;
-    void disconnect_all();
 private:
     struct IpcClient
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <miral/wayland_extensions.h>
 #include <miral/display_configuration_option.h>
 #include <miral/add_init_callback.h>
+#include <miral/append_event_filter.h>
 #include <libnotify/notify.h>
 #include <stdlib.h>
 
@@ -65,11 +66,6 @@ int main(int argc, char const* argv[])
         }
     };
 
-    config->register_listener([&auto_restarting_launcher](miracle::MiracleConfig& new_config)
-    {
-         auto_restarting_launcher.kill_all();
-    });
-
     notify_init("miracle-wm");
     return runner.run_with(
         {
@@ -87,6 +83,11 @@ int main(int argc, char const* argv[])
             config_keymap,
             external_client_launcher,
             display_configuration_options,
-            AddInitCallback(run_startup_apps)
+            AddInitCallback(run_startup_apps),
+            AppendEventFilter([&config](MirEvent const*)
+            {
+                config->try_process_change();
+                return false;
+            })
         });
 }

--- a/src/miracle_config.cpp
+++ b/src/miracle_config.cpp
@@ -763,13 +763,22 @@ void MiracleConfig::_watch(miral::MirRunner& runner)
         if (inotify_buffer.event.mask & (IN_MODIFY))
         {
             _load();
-
-            for (auto const& on_change : on_change_listeners)
-            {
-                on_change.listener(*this);
-            }
+            has_changes = true;
         }
     });
+}
+
+void MiracleConfig::try_process_change()
+{
+    std::lock_guard<std::mutex> lock(mutex);
+    if (!has_changes)
+        return;
+    
+    has_changes = false;
+    for (auto const& on_change : on_change_listeners)
+    {
+        on_change.listener(*this);
+    }
 }
 
 uint MiracleConfig::parse_modifier(std::string const& stringified_action_key)

--- a/src/miracle_config.h
+++ b/src/miracle_config.h
@@ -27,6 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <mutex>
 #include <functional>
 #include <optional>
+#include <atomic>
 
 namespace miral
 {
@@ -126,6 +127,7 @@ public:
     /// listener should be triggered earlier. A higher priority means later
     int register_listener(std::function<void(miracle::MiracleConfig&)> const&, int priority = 5);
     void unregister_listener(int handle);
+    void try_process_change();
 
 private:
     struct ChangeListener
@@ -161,6 +163,7 @@ private:
     std::string desired_terminal = "";
     int resize_jump = 50;
     std::vector<EnvironmentVariable> environment_variables;
+    std::atomic<bool> has_changes = false;
 };
 }
 

--- a/src/policy.cpp
+++ b/src/policy.cpp
@@ -64,10 +64,6 @@ Policy::Policy(
       node_interface(tools)
 {
     workspace_observer_registrar.register_interest(ipc);
-    config->register_listener([&](auto& new_config)
-    {
-        ipc->disconnect_all();
-    }, 1);
 }
 
 Policy::~Policy()

--- a/src/tiling_window_tree.cpp
+++ b/src/tiling_window_tree.cpp
@@ -676,6 +676,7 @@ void TilingWindowTree::recalculate_root_node_area()
     for (auto const& zone : screen->get_app_zones())
     {
         root_lane->set_logical_area(zone.extents());
+        root_lane->commit_changes();
         break;
     }
 }


### PR DESCRIPTION
## What's new?
- We are no longer reloading startup applications when the config gets refreshed since it was causing us to crash
- Config updates now happen in `AppendEventFilter` to ensure that they're threadsafe
- When we recalculate the root node area on config refresh, we rightfully commit those changes too