### PR TITLE
packaging: Only install unsnap wrapper when building as a snap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+option(SNAP_BUILD "Building as a snap?" OFF)
+
 find_package(PkgConfig)
 pkg_check_modules(MIRAL miral REQUIRED)
 pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0)
@@ -68,14 +70,19 @@ add_custom_target(miracle-wm-sensible-terminal ALL
     cp ${CMAKE_CURRENT_SOURCE_DIR}/src/miracle-wm-sensible-terminal ${CMAKE_BINARY_DIR}/bin
 )
 
-add_custom_target(miracle-wm-unsnap ALL
-    cp ${CMAKE_CURRENT_SOURCE_DIR}/src/miracle-wm-unsnap ${CMAKE_BINARY_DIR}/bin
-)
-
 install(PROGRAMS
     src/miracle-wm-sensible-terminal
-    src/miracle-wm-unsnap
     DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
+
+if(SNAP_BUILD)
+    add_custom_target(miracle-wm-unsnap ALL
+        cp ${CMAKE_CURRENT_SOURCE_DIR}/src/miracle-wm-unsnap ${CMAKE_BINARY_DIR}/bin
+    )
+    install(PROGRAMS
+        src/miracle-wm-unsnap
+        DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+endif()
 
 add_subdirectory(tests/)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,6 +46,8 @@ parts:
       craftctl set version=$server_version-mir$mir_version
       if echo $mir_version | grep -e '+dev' -e '~rc' -q; then craftctl set grade=devel; else craftctl set grade=stable; fi
     plugin: cmake
+    cmake-parameters:
+      - -DSNAP_BUILD=ON
     source: .
     build-packages:
       - pkg-config


### PR DESCRIPTION
This is only needed when Miracle is built as a snap, so exclude it when making regular package builds.