### PR TITLE
(#113) bugfix: fullscreen windows no longer get their rectangle set if one is pending

### DIFF
--- a/src/leaf_node.cpp
+++ b/src/leaf_node.cpp
@@ -148,7 +148,10 @@ void LeafNode::commit_changes()
     {
         logical_area = next_logical_area.value();
         next_logical_area.reset();
-        node_interface.set_rectangle(window, get_visible_area());
-        constrain();
+        if (!node_interface.is_fullscreen(window))
+        {
+            node_interface.set_rectangle(window, get_visible_area());
+            constrain();
+        }
     }
 }


### PR DESCRIPTION
fixes #113 