### PR TITLE
(#166) XWayland windows now have a proper Z-order so that they don't step on each other's toes

### DIFF
--- a/src/output_content.cpp
+++ b/src/output_content.cpp
@@ -153,7 +153,16 @@ void OutputContent::handle_window_ready(miral::WindowInfo& window_info, std::sha
     {
     case WindowType::tiled:
     {
-        metadata->get_tiling_node()->get_tree()->handle_window_ready(window_info);
+        auto tree = metadata->get_tiling_node()->get_tree();
+        tree->handle_window_ready(window_info);
+
+        // Note: By default, new windows are raised. To properly maintain the ordering, we must
+        // raise floating windows and then raise fullscreen windows.
+        for (auto const& window : get_active_workspace()->get_floating_windows())
+            node_interface.raise(window);
+
+        if (tree->has_fullscreen_window())
+            node_interface.raise(active_window);
         break;
     }
     case WindowType::floating:

--- a/src/tiling_window_tree.cpp
+++ b/src/tiling_window_tree.cpp
@@ -87,10 +87,6 @@ std::shared_ptr<LeafNode> TilingWindowTree::advise_new_window(miral::WindowInfo 
         tiling_interface.select_active_window(window_info.window());
         advise_fullscreen_window(window_info.window());
     }
-    else
-    {
-        tiling_interface.send_to_back(window_info.window());
-    }
 
     return node;
 }
@@ -302,8 +298,6 @@ void TilingWindowTree::advise_focus_gained(miral::Window& window)
     active_window = metadata->get_tiling_node();
     if (active_window && is_active_window_fullscreen)
         tiling_interface.raise(window);
-    else
-        tiling_interface.send_to_back(window);
 }
 
 void TilingWindowTree::advise_focus_lost(miral::Window& window)
@@ -808,12 +802,12 @@ void TilingWindowTree::hide()
     });
 }
 
-void TilingWindowTree::show()
+std::shared_ptr<LeafNode> TilingWindowTree::show()
 {
     if (!is_hidden)
     {
         mir::log_warning("Tree is already shown");
-        return;
+        return nullptr;
     }
 
     is_hidden = false;
@@ -828,14 +822,12 @@ void TilingWindowTree::show()
 
             if (leaf_node->is_fullscreen())
                 fullscreen_node = leaf_node;
+            else
+                tiling_interface.raise(leaf_node->get_window());
         }
     });
 
-    if (fullscreen_node)
-    {
-        tiling_interface.select_active_window(fullscreen_node->get_window());
-        tiling_interface.raise(fullscreen_node->get_window());
-    }
+    return fullscreen_node;
 }
 
 bool TilingWindowTree::is_empty()

--- a/src/tiling_window_tree.h
+++ b/src/tiling_window_tree.h
@@ -37,6 +37,7 @@ namespace miracle
 class OutputContent;
 class MiracleConfig;
 class TilingInterface;
+class LeafNode;
 
 class TilingWindowTree
 {
@@ -110,8 +111,8 @@ public:
     /// Hides the entire tree
     void hide();
 
-    /// Shows the entire tree
-    void show();
+    /// Shows the tree and returns a fullscreen node
+    std::shared_ptr<LeafNode> show();
 
     void recalculate_root_node_area();
     bool is_empty();

--- a/src/workspace_content.h
+++ b/src/workspace_content.h
@@ -64,6 +64,7 @@ private:
     std::shared_ptr<TilingWindowTree> tree;
     int workspace;
     std::vector<miral::Window> floating_windows;
+    TilingInterface& node_interface;
 };
 
 } // miracle


### PR DESCRIPTION
fixes #166 